### PR TITLE
fix: centralize authenticated session handling

### DIFF
--- a/src/components/CurrentMembershipPage.jsx
+++ b/src/components/CurrentMembershipPage.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom"; // Added for navigation
-import axios from "axios";
 import { apiUrl } from "../config/constants";
+import { authApi, isSessionExpiryError } from "../config/authClient";
 
 const CurrentMembershipPage = () => {
   const { user } = useAuth();
@@ -11,22 +11,11 @@ const CurrentMembershipPage = () => {
   const navigate = useNavigate(); // Hook for navigation
 
   useEffect(() => {
-    const userId = user.id;
+    const userId = user?.id || user?._id;
     const fetchUserSubscriptionDetails = async (userId) => {
       try {
-        const token = localStorage.getItem("token");
-        if (!token) {
-          throw new Error("Authentication token not found");
-        }
-
-        const response = await axios.get(
-          apiUrl(`/api/users/subscription/${userId}`),
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json",
-            },
-          }
+        const response = await authApi.get(
+          apiUrl(`/api/users/subscription/${userId}`)
         );
 
         console.log(">fetching user subscription details: ", response.data);
@@ -36,6 +25,10 @@ const CurrentMembershipPage = () => {
           setUserStatusDetails(expiry);
         }
       } catch (err) {
+        if (isSessionExpiryError(err)) {
+          return;
+        }
+
         console.log(err);
       }
     };

--- a/src/components/FindPartner.jsx
+++ b/src/components/FindPartner.jsx
@@ -10,6 +10,7 @@ import Header from "./Header";
 import { motion } from "framer-motion";
 import axios from "axios";
 import PropTypes from "prop-types";
+import { authApi, isSessionExpiryError } from "../config/authClient";
 
 const FindPartner = () => {
   const [filters, setFilters] = useState({
@@ -26,7 +27,7 @@ const FindPartner = () => {
   const [error, setError] = useState(null);
   const navigate = useNavigate();
   const location = useLocation();
-  const { isAuthenticated, user, refreshUser, logout } = useAuth();
+  const { isAuthenticated, user, refreshUser } = useAuth();
   const [showFilters, setShowFilters] = useState(false);
   const [currentUserGender, setCurrentUserGender] = useState(null);
   const [profileComplete, setProfileComplete] = useState(true);
@@ -153,19 +154,12 @@ const FindPartner = () => {
       if (!isAuthenticated) return;
 
       try {
-        await axios.get(apiUrl("/api/users/find-my-partner"), {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("token")}`,
-          },
-        });
+        await authApi.get(apiUrl("/api/users/find-my-partner"));
         setProfileComplete(true);
         fetchUsers();
       } catch (err) {
         console.error("Error checking profile completeness:", err);
-        if (err.response?.status === 401) {
-          alert("Session expired. Please log in again.");
-          logout();
-          navigate("/login", { replace: true });
+        if (isSessionExpiryError(err)) {
           return;
         }
 
@@ -187,7 +181,7 @@ const FindPartner = () => {
     if (isAuthenticated && authChecked) {
       checkProfileCompleteness();
     }
-  }, [isAuthenticated, authChecked, logout, navigate]);
+  }, [isAuthenticated, authChecked]);
 
   // Fetch users from API
   const fetchUsers = async () => {

--- a/src/components/ProfileImageGallery.jsx
+++ b/src/components/ProfileImageGallery.jsx
@@ -4,6 +4,7 @@ import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import { FaPlus, FaTrash, FaCheck, FaTimes, FaCamera } from "react-icons/fa";
 import { apiUrl } from "../config/constants";
+import { authFetch, isSessionExpiryError } from "../config/authClient";
 const API_URL = apiUrl("/api/users");
 
 const ProfileImageGallery = () => {
@@ -118,11 +119,11 @@ const ProfileImageGallery = () => {
   const fetchImages = async () => {
     if (!user?._id) return;
     try {
-      const response = await fetch(`${API_URL}/${user._id}`, {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-      });
+      const response = await authFetch(`${API_URL}/${user._id}`);
+      if (!response.ok) {
+        throw new Error("Failed to fetch profile images");
+      }
+
       const data = await response.json();
       if (data.profile_pictures) {
         setImages(data.profile_pictures);
@@ -132,6 +133,10 @@ const ProfileImageGallery = () => {
         data.profile_picture || data.profile_pictures?.[0] || ""
       );
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error fetching profile images:", error);
     }
   };
@@ -289,13 +294,13 @@ const ProfileImageGallery = () => {
       const formData = new FormData();
       formData.append("profile_pictures", croppedFile);
 
-      const response = await fetch(`${API_URL}/${user._id}/upload`, {
+      const response = await authFetch(`${API_URL}/${user._id}/upload`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
         body: formData,
       });
+      if (!response.ok) {
+        throw new Error("Failed to upload profile image");
+      }
 
       const data = await response.json();
       if (data.profile_pictures) {
@@ -308,6 +313,10 @@ const ProfileImageGallery = () => {
         await refreshUser();
       }
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error uploading cropped image:", error);
     } finally {
       // Clean up
@@ -335,11 +344,10 @@ const ProfileImageGallery = () => {
     setOperation("deleting");
 
     try {
-      const response = await fetch(`${API_URL}/${user._id}/delete-picture`, {
+      const response = await authFetch(`${API_URL}/${user._id}/delete-picture`, {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
         },
         body: JSON.stringify({ imagePath: imageUrl }),
       });
@@ -354,6 +362,10 @@ const ProfileImageGallery = () => {
         await refreshUser();
       }
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error deleting image:", error);
     } finally {
       setOperation(null);
@@ -369,13 +381,12 @@ const ProfileImageGallery = () => {
 
     setOperation("setting-profile");
     try {
-      const response = await fetch(
+      const response = await authFetch(
         `${API_URL}/${user._id}/set-profile-picture`,
         {
           method: "PUT",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${localStorage.getItem("token")}`,
           },
           body: JSON.stringify({ imageUrl }),
         }
@@ -389,6 +400,10 @@ const ProfileImageGallery = () => {
         alert(data.message || "Failed to set profile picture");
       }
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error setting profile picture:", error);
       alert("Failed to set profile picture");
     } finally {

--- a/src/components/Profilepage.jsx
+++ b/src/components/Profilepage.jsx
@@ -11,6 +11,7 @@ import ProfileImageGallery from "./ProfileImageGallery";
 // Removed unused password icons
 import { MdPrivacyTip } from "react-icons/md";
 import { apiUrl } from "../config/constants";
+import { authApi, authFetch, isSessionExpiryError } from "../config/authClient";
 
 // Helper functions moved outside the component for better performance
 const generateFeetOptions = () => {
@@ -584,16 +585,8 @@ export default function ProfileSettings() {
 
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        navigate("/login");
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/users/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/users/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -659,13 +652,14 @@ export default function ProfileSettings() {
         looking_for: userData.looking_for || "",
       });
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error fetching user details:", error);
 
       // Handle authentication errors
-      if (error.response?.status === 401 || error.response?.status === 403) {
-        alert("Session expired. Please log in again.");
-        localStorage.removeItem("token");
-        localStorage.removeItem("currentUser");
+      if (error.response?.status === 403) {
         navigate("/login");
         return;
       }
@@ -683,16 +677,8 @@ export default function ProfileSettings() {
 
     setLoadingAstrology(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/astrologies/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/astrologies/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Accept: "application/json",
         },
@@ -700,11 +686,12 @@ export default function ProfileSettings() {
 
       setAstrologyData(response.data);
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error fetching astrology details:", error);
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else {
+      if (error.response?.status !== 401) {
         console.log("Failed to fetch astrology details.");
         // alert("Failed to fetch astrology details.");
       }
@@ -718,26 +705,19 @@ export default function ProfileSettings() {
 
     setLoadingProfession(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/professions/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/professions/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
 
       setProfessionData(response.data);
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
+      if (error.response?.status !== 401) {
         console.error("Error fetching profession details:", error);
         // alert("Failed to fetch profession details.");
       }
@@ -751,26 +731,19 @@ export default function ProfileSettings() {
 
     setLoadingFamily(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/families/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/families/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
 
       setFamilyData(response.data);
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
+      if (error.response?.status !== 401) {
         console.error("Error fetching family details:", error);
         // alert("Failed to fetch family details.");
       }
@@ -784,26 +757,19 @@ export default function ProfileSettings() {
 
     setLoadingEducation(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/educations/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/educations/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
 
       setEducationData(response.data);
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
+      if (error.response?.status !== 401) {
         console.error("Error fetching education details:", error);
         // alert("Failed to fetch education details.");
       }
@@ -1013,8 +979,6 @@ export default function ProfileSettings() {
   const handleSave = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-
       // Since we no longer convert "yes"/"no"/"occasionally" to booleans,
       // we keep drink/smoke as strings in personalData.lifestyle
       const fixedLifestyle = { ...personalData.lifestyle };
@@ -1057,9 +1021,8 @@ export default function ProfileSettings() {
       console.log("Saving manglik value:", personalData.manglik);
       console.log("Full request body:", requestBody);
 
-      await axios.put(apiUrl(`/api/users/${user._id}`), requestBody, {
+      await authApi.put(apiUrl(`/api/users/${user._id}`), requestBody, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -1072,6 +1035,10 @@ export default function ProfileSettings() {
 
       alert("Profile updated successfully!");
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error saving profile:", error);
       alert("Failed to update profile.");
     } finally {
@@ -1087,11 +1054,8 @@ export default function ProfileSettings() {
   const handleSaveProfession = async () => {
     setLoadingProfession(true);
     try {
-      const token = localStorage.getItem("token");
-
-      await axios.put(apiUrl(`/api/professions/${user._id}`), professionData, {
+      await authApi.put(apiUrl(`/api/professions/${user._id}`), professionData, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -1099,6 +1063,10 @@ export default function ProfileSettings() {
       setIsEditingProfession(false);
       alert("Profession details updated successfully!");
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error saving profession details:", error);
       alert("Failed to update profession details. Please try again.");
     }
@@ -1113,16 +1081,8 @@ export default function ProfileSettings() {
   const handleSaveFamily = async () => {
     setLoadingFamily(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      await axios.put(apiUrl(`/api/families/${user._id}`), familyData, {
+      await authApi.put(apiUrl(`/api/families/${user._id}`), familyData, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -1130,6 +1090,10 @@ export default function ProfileSettings() {
       setIsEditingFamily(false);
       alert("Family details updated successfully!");
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error saving family details:", error);
       alert("Failed to update family details. Please try again.");
     }
@@ -1144,11 +1108,8 @@ export default function ProfileSettings() {
   const handleSaveEducation = async () => {
     setLoadingEducation(true);
     try {
-      const token = localStorage.getItem("token");
-
-      await axios.put(apiUrl(`/api/educations/${user._id}`), educationData, {
+      await authApi.put(apiUrl(`/api/educations/${user._id}`), educationData, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -1156,6 +1117,10 @@ export default function ProfileSettings() {
       setIsEditingEducation(false);
       alert("Education details updated successfully!");
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error saving education details:", error);
       alert("Failed to update education details. Please try again.");
     }
@@ -1170,20 +1135,11 @@ export default function ProfileSettings() {
   const handleSaveAstrology = async () => {
     setLoadingAstrology(true);
     try {
-      const token = localStorage.getItem("token");
-
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.put(
+      const response = await authApi.put(
         apiUrl(`/api/astrologies/${user._id}`),
         astrologyData,
         {
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
         }
@@ -1196,10 +1152,11 @@ export default function ProfileSettings() {
         alert("Unexpected response from server. Please try again.");
       }
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else if (error.response?.status === 500) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
+      if (error.response?.status === 500) {
         alert("Server error! Please try again later.");
       } else {
         console.error("Error saving astrology details:", error);
@@ -1249,17 +1206,9 @@ export default function ProfileSettings() {
     );
     if (!confirmed) return;
 
-    const token = localStorage.getItem("token");
-    if (!token) {
-      alert("Session expired. Please log in again.");
-      navigate("/login");
-      return;
-    }
-
     try {
-      const response = await fetch(apiUrl("/api/users/me"), {
+      const response = await authFetch(apiUrl("/api/users/me"), {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
       });
       if (!response.ok) {
         const msg = await response.text();
@@ -1269,6 +1218,10 @@ export default function ProfileSettings() {
       logout();
       navigate("/");
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Delete account error:", error);
       alert("Could not delete the account. Please try again.");
     }

--- a/src/components/membershipPage.jsx
+++ b/src/components/membershipPage.jsx
@@ -2,10 +2,10 @@ import React, { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
-import axios from "axios";
 import Header from "./Header";
 import Footer from "./Footer";
 import { apiUrl } from "../config/constants";
+import { authApi, isSessionExpiryError } from "../config/authClient";
 
 const MembershipPage = () => {
   const [plans, setPlans] = useState([]);
@@ -179,19 +179,12 @@ const MembershipPage = () => {
     }
 
     try {
-      // Verify token presence
-      const token = localStorage.getItem("token");
-      if (!token) {
-        throw new Error("Authentication token not found");
-      }
-
       // Call API to validate coupon
-      const response = await axios.post(
+      const response = await authApi.post(
         apiUrl("/api/coupons/validate"),
         { code: formData.couponCode },
         {
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
         }
@@ -224,6 +217,10 @@ const MembershipPage = () => {
         throw new Error(response.data?.message || "Failed to apply coupon");
       }
     } catch (err) {
+      if (isSessionExpiryError(err)) {
+        return;
+      }
+
       console.error("Coupon application error:", err);
       setError(
         err.response?.data?.message ||
@@ -253,12 +250,6 @@ const MembershipPage = () => {
     }
 
     try {
-      // Verify token presence
-      const token = localStorage.getItem("token");
-      if (!token) {
-        throw new Error("Authentication token not found");
-      }
-
       // Create form data for submission with only the required fields
       const formDataToSubmit = new FormData();
       formDataToSubmit.append("fullName", formData.name);
@@ -273,12 +264,11 @@ const MembershipPage = () => {
         // formDataToSubmit.append('finalPrice', finalPrice);
       }
 
-      const response = await axios.post(
+      const response = await authApi.post(
         apiUrl("/api/users/subscribe"),
         formDataToSubmit,
         {
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "multipart/form-data",
           },
         }
@@ -296,6 +286,10 @@ const MembershipPage = () => {
         throw new Error(response.data?.message || "Payment submission failed");
       }
     } catch (err) {
+      if (isSessionExpiryError(err)) {
+        return;
+      }
+
       console.error("Payment submission error:", err);
       setError(err.message || "Failed to process payment. Please try again.");
     } finally {

--- a/src/components/profile/AstrologySection.jsx
+++ b/src/components/profile/AstrologySection.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import { InfoRow, SectionContainer, EditButtons } from "./ProfileUtils";
 import { apiUrl } from "../../config/constants";
+import { authApi, isSessionExpiryError } from "../../config/authClient";
 
-const AstrologySection = ({ user, logout }) => {
+const AstrologySection = ({ user }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);
   const [astrologyData, setAstrologyData] = useState({
@@ -22,16 +22,8 @@ const AstrologySection = ({ user, logout }) => {
 
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/astrologies/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/astrologies/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Accept: "application/json",
         },
@@ -39,11 +31,12 @@ const AstrologySection = ({ user, logout }) => {
 
       setAstrologyData(response.data);
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error fetching astrology details:", error);
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else {
+      if (error.response?.status !== 401) {
         // alert("Failed to fetch astrology details.");
         console.log("Failed to fetch astrology details.", error);
       }
@@ -62,20 +55,11 @@ const AstrologySection = ({ user, logout }) => {
   const handleSave = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.put(
+      const response = await authApi.put(
         apiUrl(`/api/astrologies/${user._id}`),
         astrologyData,
         {
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
         }
@@ -88,10 +72,11 @@ const AstrologySection = ({ user, logout }) => {
         alert("Unexpected response from server. Please try again.");
       }
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else if (error.response?.status === 500) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
+      if (error.response?.status === 500) {
         alert("Server error! Please try again later.");
       } else {
         console.error("Error saving astrology details:", error);

--- a/src/components/profile/EducationSection.jsx
+++ b/src/components/profile/EducationSection.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import { InfoRow, SectionContainer, EditButtons } from "./ProfileUtils";
 import { apiUrl } from "../../config/constants";
+import { authApi, isSessionExpiryError } from "../../config/authClient";
 
-const EducationSection = ({ user, logout }) => {
+const EducationSection = ({ user }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);
   const [educationData, setEducationData] = useState({
@@ -27,26 +27,19 @@ const EducationSection = ({ user, logout }) => {
 
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/educations/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/educations/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
 
       setEducationData(response.data);
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
+      if (error.response?.status !== 401) {
         console.error("Error fetching education details:", error);
         // alert("Failed to fetch education details.");
       }
@@ -74,11 +67,8 @@ const EducationSection = ({ user, logout }) => {
   const handleSave = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-
-      await axios.put(apiUrl(`/api/educations/${user._id}`), educationData, {
+      await authApi.put(apiUrl(`/api/educations/${user._id}`), educationData, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -86,6 +76,10 @@ const EducationSection = ({ user, logout }) => {
       setIsEditing(false);
       alert("Education details updated successfully!");
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error saving education details:", error);
       alert("Failed to update education details. Please try again.");
     }

--- a/src/components/profile/FamilyDetailsSection.jsx
+++ b/src/components/profile/FamilyDetailsSection.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import { InfoRow, SectionContainer, EditButtons } from "./ProfileUtils";
 import { apiUrl } from "../../config/constants";
+import { authApi, isSessionExpiryError } from "../../config/authClient";
 
-const FamilyDetailsSection = ({ user, logout }) => {
+const FamilyDetailsSection = ({ user }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);
   const [familyData, setFamilyData] = useState({
@@ -34,26 +34,19 @@ const FamilyDetailsSection = ({ user, logout }) => {
 
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/families/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/families/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
 
       setFamilyData(response.data);
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
+      if (error.response?.status !== 401) {
         console.error("Error fetching family details:", error);
         // alert("Failed to fetch family details.");
       }
@@ -84,16 +77,8 @@ const FamilyDetailsSection = ({ user, logout }) => {
   const handleSave = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      await axios.put(apiUrl(`/api/families/${user._id}`), familyData, {
+      await authApi.put(apiUrl(`/api/families/${user._id}`), familyData, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -101,6 +86,10 @@ const FamilyDetailsSection = ({ user, logout }) => {
       setIsEditing(false);
       alert("Family details updated successfully!");
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error saving family details:", error);
       alert("Failed to update family details. Please try again.");
     }

--- a/src/components/profile/ProfessionSection.jsx
+++ b/src/components/profile/ProfessionSection.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import { InfoRow, SectionContainer, EditButtons } from "./ProfileUtils";
 import { apiUrl } from "../../config/constants";
+import { authApi, isSessionExpiryError } from "../../config/authClient";
 
-const ProfessionSection = ({ user, logout }) => {
+const ProfessionSection = ({ user }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);
   const [professionData, setProfessionData] = useState({
@@ -28,26 +28,19 @@ const ProfessionSection = ({ user, logout }) => {
 
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/professions/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/professions/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
 
       setProfessionData(response.data);
     } catch (error) {
-      if (error.response?.status === 401) {
-        alert("Session expired. Please log in again.");
-        logout();
-      } else {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
+      if (error.response?.status !== 401) {
         console.error("Error fetching profession details:", error);
         // alert("Failed to fetch profession details.");
       }
@@ -80,11 +73,8 @@ const ProfessionSection = ({ user, logout }) => {
   const handleSave = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-
-      await axios.put(apiUrl(`/api/professions/${user._id}`), professionData, {
+      await authApi.put(apiUrl(`/api/professions/${user._id}`), professionData, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -92,6 +82,10 @@ const ProfessionSection = ({ user, logout }) => {
       setIsEditing(false);
       alert("Profession details updated successfully!");
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error saving profession details:", error);
       alert("Failed to update profession details. Please try again.");
     }

--- a/src/components/profile/ProfileInfoSection.jsx
+++ b/src/components/profile/ProfileInfoSection.jsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import { InfoRow, SectionContainer, EditButtons } from "./ProfileUtils";
 import { apiUrl } from "../../config/constants";
+import { authApi, isSessionExpiryError } from "../../config/authClient";
 
 function ProfileInfoSection({
   user,
-  updateUser,
   setBasicData: setParentBasicData,
   setPersonalData: setParentPersonalData,
   setHobbiesData: setParentHobbiesData,
@@ -100,15 +99,8 @@ function ProfileInfoSection({
 
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        return;
-      }
-
-      const response = await axios.get(apiUrl(`/api/users/${user._id}`), {
+      const response = await authApi.get(apiUrl(`/api/users/${user._id}`), {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -167,6 +159,10 @@ function ProfileInfoSection({
         newHobby: "",
       });
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error fetching user details:", error);
       // alert("Failed to fetch user details.");
     }
@@ -206,7 +202,6 @@ function ProfileInfoSection({
   const handleSave = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
       // Build payload and normalize lifestyle.abroad_ready to boolean|null
       const payload = {
         ...basicData,
@@ -221,9 +216,8 @@ function ProfileInfoSection({
         else payload.lifestyle.abroad_ready = null; // for "" or undefined -> null
       }
 
-      await axios.put(apiUrl(`/api/users/${user._id}`), payload, {
+      await authApi.put(apiUrl(`/api/users/${user._id}`), payload, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
       });
@@ -231,6 +225,10 @@ function ProfileInfoSection({
       setIsEditing(false);
       alert("Profile updated successfully!");
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error saving profile:", error);
       alert("Failed to update profile.");
     }

--- a/src/config/authClient.js
+++ b/src/config/authClient.js
@@ -1,0 +1,93 @@
+import axios from "axios";
+
+export const SESSION_EXPIRED_EVENT = "auth:session-expired";
+
+const SESSION_EXPIRED_CODE = "SESSION_EXPIRED";
+let hasHandledSessionExpiry = false;
+
+export const clearStoredSession = () => {
+  localStorage.removeItem("token");
+  localStorage.removeItem("currentUser");
+};
+
+export const getStoredToken = () => localStorage.getItem("token");
+
+const createSessionExpiredError = () => {
+  const error = new Error("Session expired. Please log in again.");
+  error.code = SESSION_EXPIRED_CODE;
+  error.isSessionExpired = true;
+  return error;
+};
+
+export const isSessionExpiryError = (error) =>
+  Boolean(
+    error?.isSessionExpired ||
+      error?.code === SESSION_EXPIRED_CODE ||
+      error?.response?.status === 401
+  );
+
+export const handleSessionExpiry = () => {
+  clearStoredSession();
+  window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
+
+  if (!hasHandledSessionExpiry) {
+    hasHandledSessionExpiry = true;
+    window.alert("Session expired. Please log in again.");
+
+    if (window.location.pathname !== "/login") {
+      window.location.replace("/login");
+    }
+  }
+
+  return createSessionExpiredError();
+};
+
+export const authApi = axios.create();
+
+authApi.interceptors.request.use(
+  (config) => {
+    const token = getStoredToken();
+
+    if (!token) {
+      return Promise.reject(handleSessionExpiry());
+    }
+
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+authApi.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error?.response?.status === 401) {
+      return Promise.reject(handleSessionExpiry());
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export const authFetch = async (input, init = {}) => {
+  const token = getStoredToken();
+
+  if (!token) {
+    throw handleSessionExpiry();
+  }
+
+  const headers = new Headers(init.headers || {});
+  headers.set("Authorization", `Bearer ${token}`);
+
+  const response = await fetch(input, {
+    ...init,
+    headers,
+  });
+
+  if (response.status === 401) {
+    throw handleSessionExpiry();
+  }
+
+  return response;
+};

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,6 +1,12 @@
 import React, { createContext, useState, useEffect, useContext } from "react";
 import axios from "axios";
 import { apiUrl } from "../config/constants";
+import {
+  SESSION_EXPIRED_EVENT,
+  authApi,
+  clearStoredSession,
+  isSessionExpiryError,
+} from "../config/authClient";
 
 const AuthContext = createContext();
 
@@ -12,7 +18,7 @@ export const AuthProvider = ({ children }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
+  const syncAuthStateFromStorage = () => {
     const token = localStorage.getItem("token");
     if (token) {
       const storedUser = localStorage.getItem("currentUser");
@@ -34,7 +40,22 @@ export const AuthProvider = ({ children }) => {
         setUser(null);
         setIsAuthenticated(false);
       }
+    } else {
+      setUser(null);
+      setIsAuthenticated(false);
     }
+  };
+
+  useEffect(() => {
+    syncAuthStateFromStorage();
+
+    window.addEventListener(SESSION_EXPIRED_EVENT, syncAuthStateFromStorage);
+    return () => {
+      window.removeEventListener(
+        SESSION_EXPIRED_EVENT,
+        syncAuthStateFromStorage
+      );
+    };
   }, []);
 
   const login = async (credentials) => {
@@ -67,27 +88,18 @@ export const AuthProvider = ({ children }) => {
   };
 
   const logout = () => {
-    localStorage.removeItem("currentUser");
-    localStorage.removeItem("token");
+    clearStoredSession();
     setUser(null);
     setIsAuthenticated(false);
   };
 
   const updateUser = async (updatedUserData) => {
     try {
-      const token = localStorage.getItem("token");
-      if (!token) {
-        alert("Session expired. Please log in again.");
-        logout();
-        return false;
-      }
-
-      const response = await axios.put(
+      const response = await authApi.put(
         apiUrl(`/api/users/${user._id}`),
         updatedUserData,
         {
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
         }
@@ -102,6 +114,10 @@ export const AuthProvider = ({ children }) => {
         return false;
       }
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return false;
+      }
+
       console.error("Error updating user:", error);
       alert("An error occurred while updating the profile.");
       return false;
@@ -111,18 +127,20 @@ export const AuthProvider = ({ children }) => {
   // We'll rely on refreshUser() after uploading/deleting pictures:
   const refreshUser = async () => {
     try {
-      const token = localStorage.getItem("token");
-      if (!token || !user) return;
+      const userId = user?._id || user?.id;
+      if (!userId) return;
 
-      const response = await axios.get(apiUrl(`/api/users/${user._id}`), {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const response = await authApi.get(apiUrl(`/api/users/${userId}`));
 
       if (response.data) {
         localStorage.setItem("currentUser", JSON.stringify(response.data));
         setUser(response.data);
       }
     } catch (error) {
+      if (isSessionExpiryError(error)) {
+        return;
+      }
+
       console.error("Error refreshing user data:", error);
     }
   };


### PR DESCRIPTION
Summary:
Centralizes authenticated session handling for protected user flows.

What changed:
- added shared authenticated request layer for axios/fetch
- standardized 401 handling to clear session, alert once, and redirect to login
- migrated protected flows in profile, find partner, membership, and current plan

Local testing completed:
- forced invalid token on /profile, /findpartner, /membership, /current-plan
- confirmed session-expired alert + logout + redirect
- confirmed profile photo fetch/upload/delete still works with valid session
- confirmed membership coupon/apply flow still works with valid session

Preview limitation:
- Vercel preview cannot fully call the backend because production backend CORS does not currently allow arbitrary preview domains